### PR TITLE
Broken link in comment

### DIFF
--- a/bottleneck/src/template/move.pyx
+++ b/bottleneck/src/template/move.pyx
@@ -1,7 +1,7 @@
 #cython: embedsignature=True
 
 # The minimum on a sliding window algorithm by Richard Harter
-# http://home.tiac.net/~cri/2001/slidingmin.html
+# http://www.richardhartersworld.com/cri/2001/slidingmin.html
 # Original C code:
 # Copyright Richard Harter 2009
 # Released under a Simplified BSD license


### PR DESCRIPTION
Richard Harter's webpage was taken offline after his passing in 2012. Fortunately, the whole site was cloned and put back online at http://www.richardhartersworld.com/, this corrects the link to his original code.