### PR TITLE
Minimal change in metadata that fixes the top_level.txt file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,13 +57,7 @@ MINOR = VER[1]
 MICRO = VER[2]
 ISRELEASED = False
 VERSION = '%s.%s.%s' % (MAJOR, MINOR, MICRO)
-PACKAGES = ["bottleneck",
-            "bottleneck/slow",
-            "bottleneck/tests",
-            "bottleneck/benchmark",
-            "bottleneck/src",
-            "bottleneck/src/template",
-            "bottleneck/src/auto_pyx"]
+PACKAGES = ['bottleneck']
 PACKAGE_DATA = {'bottleneck': ['LICENSE']}
 REQUIRES = ["numpy"]
 
@@ -92,15 +86,14 @@ if not(len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or \
        sys.argv[1] in ('--help-commands', 'egg_info', '--version', 'clean'))):
 
     import numpy as np
-    metadata['ext_package'] = 'bottleneck'
     metadata['ext_modules'] = \
-                              [Extension("reduce", sources=["bottleneck/src/auto_pyx/reduce.c"],
+                              [Extension("bottleneck.reduce", sources=["bottleneck/src/auto_pyx/reduce.c"],
                                          include_dirs=[np.get_include()]),
-                               Extension("nonreduce", sources=["bottleneck/src/auto_pyx/nonreduce.c"],
+                               Extension("bottleneck.nonreduce", sources=["bottleneck/src/auto_pyx/nonreduce.c"],
                                          include_dirs=[np.get_include()]),
-                               Extension("nonreduce_axis", sources=["bottleneck/src/auto_pyx/nonreduce_axis.c"],
+                               Extension("bottleneck.nonreduce_axis", sources=["bottleneck/src/auto_pyx/nonreduce_axis.c"],
                                          include_dirs=[np.get_include()]),
-                               Extension("move", sources=["bottleneck/src/auto_pyx/move.c"],
+                               Extension("bottleneck.move", sources=["bottleneck/src/auto_pyx/move.c"],
                                          extra_compile_args=["-std=gnu89"],
                                          include_dirs=[np.get_include()])]
 


### PR DESCRIPTION
This fixes #106 and looks ok to my non-expert eyes. The fix has two components:
- The paths in `PACKAGES` were certainly wrong, I could use `find_packages()`, but the explicit `'bottleneck'` is ok as well.
- I'm not sure if you have a reason for using `ext_package` instead of full names in `ext_modules`, but the looking at the [python distribution docs](https://docs.python.org/2/distutils/setupscript.html#extension-names-and-packages) it feels safe.

Tests pass on my machine for 2.7 and 3.5, except the known failure in the median.
