### PR TITLE
Minimal change in metadata that fixes the top_level.txt file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
     from ez_setup import use_setuptools
     use_setuptools()
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from setuptools.extension import Extension
 
 CLASSIFIERS = ["Development Status :: 4 - Beta",
@@ -57,13 +57,7 @@ MINOR = VER[1]
 MICRO = VER[2]
 ISRELEASED = False
 VERSION = '%s.%s.%s' % (MAJOR, MINOR, MICRO)
-PACKAGES = ["bottleneck",
-            "bottleneck/slow",
-            "bottleneck/tests",
-            "bottleneck/benchmark",
-            "bottleneck/src",
-            "bottleneck/src/template",
-            "bottleneck/src/auto_pyx"]
+PACKAGES = find_packages()
 PACKAGE_DATA = {'bottleneck': ['LICENSE']}
 REQUIRES = ["numpy"]
 
@@ -92,15 +86,14 @@ if not(len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or \
        sys.argv[1] in ('--help-commands', 'egg_info', '--version', 'clean'))):
 
     import numpy as np
-    metadata['ext_package'] = 'bottleneck'
     metadata['ext_modules'] = \
-                              [Extension("reduce", sources=["bottleneck/src/auto_pyx/reduce.c"],
+                              [Extension("bottleneck.reduce", sources=["bottleneck/src/auto_pyx/reduce.c"],
                                          include_dirs=[np.get_include()]),
-                               Extension("nonreduce", sources=["bottleneck/src/auto_pyx/nonreduce.c"],
+                               Extension("bottleneck.nonreduce", sources=["bottleneck/src/auto_pyx/nonreduce.c"],
                                          include_dirs=[np.get_include()]),
-                               Extension("nonreduce_axis", sources=["bottleneck/src/auto_pyx/nonreduce_axis.c"],
+                               Extension("bottleneck.nonreduce_axis", sources=["bottleneck/src/auto_pyx/nonreduce_axis.c"],
                                          include_dirs=[np.get_include()]),
-                               Extension("move", sources=["bottleneck/src/auto_pyx/move.c"],
+                               Extension("bottleneck.move", sources=["bottleneck/src/auto_pyx/move.c"],
                                          extra_compile_args=["-std=gnu89"],
                                          include_dirs=[np.get_include()])]
 


### PR DESCRIPTION
Second attempt at fixing issue #106.

I had problems with sys.path and install vs. develop installs, but I think I figured it out at last. I now trust tox for testing.

The top_level.txt file is now correct:
```
$ cat Bottleneck.egg-info/top_level.txt 
bottleneck
```
And this is the tox output after I added a py35_np191 testenv as I don't have a python3.4 installation on my machine:
```
$ tox
GLOB sdist-make: /Users/amici/devel/bottleneck/setup.py
py27_np191 inst-nodeps: /Users/amici/devel/bottleneck/.tox/dist/Bottleneck-1.1.0.dev0.zip
py27_np191 runtests: PYTHONHASHSEED='2016462959'
py27_np191 runtests: commands[0] | /Users/amici/devel/bottleneck/.tox/py27_np191/bin/python /Users/amici/devel/bottleneck/tools/test-installed-bottleneck.py
Running unit tests for bottleneck
NumPy version 1.9.1
NumPy is installed in /Users/amici/devel/bottleneck/.tox/py27_np191/lib/python2.7/site-packages/numpy
Python version 2.7.11 (default, Dec  5 2015, 14:44:53) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.1.76)]
nose version 1.3.7
...............................................................................
----------------------------------------------------------------------
Ran 79 tests in 83.393s

OK
py34_np191 recreate: /Users/amici/devel/bottleneck/.tox/py34_np191
ERROR: InterpreterNotFound: python3.4
py35_np191 create: /Users/amici/devel/bottleneck/.tox/py35_np191
py35_np191 installdeps: nose, numpy==1.9.1
py35_np191 inst: /Users/amici/devel/bottleneck/.tox/dist/Bottleneck-1.1.0.dev0.zip
py35_np191 runtests: PYTHONHASHSEED='2016462959'
py35_np191 runtests: commands[0] | /Users/amici/devel/bottleneck/.tox/py35_np191/bin/python /Users/amici/devel/bottleneck/tools/test-installed-bottleneck.py
Running unit tests for bottleneck
NumPy version 1.9.1
NumPy is installed in /Users/amici/devel/bottleneck/.tox/py35_np191/lib/python3.5/site-packages/numpy
Python version 3.5.1 (default, Dec  7 2015, 21:59:10) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.1.76)]
nose version 1.3.7
...............................................................................
----------------------------------------------------------------------
Ran 79 tests in 92.646s

OK
_____________________________________________ summary _____________________________________________
  py27_np191: commands succeeded
ERROR:   py34_np191: InterpreterNotFound: python3.4
  py35_np191: commands succeeded
```