### PR TITLE
Expand testing to sdist and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,31 @@ sudo: false
 matrix:
     include:
         - os: linux
+          env: DEPS="flake8" PYTHON_VERSION="2.7" PYTHON_ARCH="64" RUN="style"
+        - os: linux
           env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64"
         - os: linux
           env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64"
         - os: linux
           env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64"
+        - os: linux
+          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64" RUN="sdist"
+        - os: linux
+          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64" RUN="sdist"
+        - os: linux
+          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64" RUN="sdist"
         - os: osx
           env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64"
         - os: osx
           env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64"
         - os: osx
           env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64"
+        - os: osx
+          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64" RUN="sdist"
+        - os: osx
+          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64" RUN="sdist"
+        - os: osx
+          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64" RUN="sdist"
 
 before_install:
     - uname -a
@@ -23,10 +37,9 @@ install:
     - source "ci/travis/conda_install.sh"
 
 script:
-    - pip install .
-    - python "tools/test-installed-bottleneck.py"
+    - source "ci/travis/bn_setup.sh"
 
 notifications:
     email:
         on_success: never
-        on_failure: never
+        on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,31 +3,19 @@ sudo: false
 matrix:
     include:
         - os: linux
-          env: DEPS="flake8" PYTHON_VERSION="2.7" PYTHON_ARCH="64" RUN="style"
+          env: TEST_DEPS="flake8" PYTHON_VERSION="2.7" PYTHON_ARCH="64" TEST_RUN="style"
         - os: linux
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64"
+          env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64"
         - os: linux
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64"
+          env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64" TEST_RUN="sdist"
         - os: linux
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64"
-        - os: linux
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64" RUN="sdist"
-        - os: linux
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64" RUN="sdist"
-        - os: linux
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64" RUN="sdist"
+          env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64" TEST_RUN="cythonless"
         - os: osx
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64"
+          env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64" TEST_RUN="cythonless"
         - os: osx
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64"
+          env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64"
         - os: osx
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64"
-        - os: osx
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64" RUN="sdist"
-        - os: osx
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.4" PYTHON_ARCH="64" RUN="sdist"
-        - os: osx
-          env: DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64" RUN="sdist"
+          env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64" TEST_RUN="sdist"
 
 before_install:
     - uname -a

--- a/ci/travis/bn_setup.sh
+++ b/ci/travis/bn_setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ev # exit on first error, print commands
+
+if [ "${RUN}" = "style" ]; then
+    flake8 bottleneck
+elif [ "${RUN}" = "sdist" ]; then
+    python setup.py sdist
+    conda uninstall -n "${NAME}" cython
+    ARCHIVE=`ls dist/*.tar.gz`
+    pip install --verbose "${ARCHIVE[0]}"
+    python "tools/test-installed-bottleneck.py"
+else
+    pip install --verbose "."
+    python "tools/test-installed-bottleneck.py"
+fi

--- a/ci/travis/bn_setup.sh
+++ b/ci/travis/bn_setup.sh
@@ -2,11 +2,16 @@
 
 set -ev # exit on first error, print commands
 
-if [ "${RUN}" = "style" ]; then
+if [ "${TEST_RUN}" = "style" ]; then
     flake8 bottleneck
-elif [ "${RUN}" = "sdist" ]; then
+elif [ "${TEST_RUN}" = "cythonless" ]; then
     python setup.py sdist
-    conda uninstall -n "${NAME}" cython
+    conda uninstall -n "${TEST_NAME}" cython
+    ARCHIVE=`ls dist/*.tar.gz`
+    pip install --verbose "${ARCHIVE[0]}"
+    python "tools/test-installed-bottleneck.py"
+elif [ "${TEST_RUN}" = "sdist" ]; then
+    python setup.py sdist
     ARCHIVE=`ls dist/*.tar.gz`
     pip install --verbose "${ARCHIVE[0]}"
     python "tools/test-installed-bottleneck.py"

--- a/ci/travis/conda_install.sh
+++ b/ci/travis/conda_install.sh
@@ -5,13 +5,19 @@ set -ev # exit on first error, print commands
 if [ "${PYTHON_ARCH}" == "32" ]; then
   set CONDA_FORCE_32BIT=1
 fi
-NAME="test-python-${PYTHON_VERSION}_${PYTHON_ARCH}bit"
+if [ -n "${TEST_RUN}" ]; then
+    TEST_NAME="test-${TEST_RUN}-python-${PYTHON_VERSION}_${PYTHON_ARCH}bit"
+else
+    TEST_NAME="test-python-${PYTHON_VERSION}_${PYTHON_ARCH}bit"
+fi
+export TEST_NAME
 # split dependencies into separate packages
-IFS=" " DEPS=(${DEPS})
-conda create -q -n "${NAME}" "${DEPS[@]}" python="${PYTHON_VERSION}"
+IFS=" " TEST_DEPS=(${TEST_DEPS})
+echo "Creating environment '${TEST_NAME}'..."
+conda create -q -n "${TEST_NAME}" "${TEST_DEPS[@]}" python="${PYTHON_VERSION}"
 
 set +v # we dont want to  see commands in the conda script
 
-source activate "${NAME}"
+source activate "${TEST_NAME}"
 conda info -a
 conda list

--- a/ci/travis/conda_setup.sh
+++ b/ci/travis/conda_setup.sh
@@ -2,24 +2,29 @@
 
 set -ev # exit on first error, print commands
 
-MINICONDA_URL="http://repo.continuum.io/miniconda"
+CONDA_URL="http://repo.continuum.io/miniconda"
 
 if [ "${PYTHON_VERSION:0:1}" == "2" ]; then
-    MINICONDA="Miniconda2"
+    CONDA="Miniconda2"
 else
-    MINICONDA="Miniconda3"
+    CONDA="Miniconda3"
 fi
 if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-    MINICONDA_OS="MacOSX"
+    CONDA_OS="MacOSX"
 else
-    MINICONDA_OS="Linux"
+    CONDA_OS="Linux"
 fi
 if [ "${PYTHON_ARCH}" == "64" ]; then
-    URL="${MINICONDA_URL}/${MINICONDA}-latest-${MINICONDA_OS}-x86_64.sh"
+    URL="${CONDA_URL}/${CONDA}-latest-${CONDA_OS}-x86_64.sh"
 else
-    URL="${MINICONDA_URL}/${MINICONDA}-latest-${MINICONDA_OS}-x86.sh"
+    URL="${CONDA_URL}/${CONDA}-latest-${CONDA_OS}-x86.sh"
 fi
+echo "Downloading '${URL}'..."
+
+set +e
 travis_retry wget "${URL}" -O miniconda.sh
+set -e
+
 chmod +x miniconda.sh
 ./miniconda.sh -b -p "${HOME}/miniconda"
 export PATH="${HOME}/miniconda/bin:${PATH}"


### PR DESCRIPTION
I left in Python 3.4 since it's the standard version for Debian and Ubuntu (which I'm using currently). Not sure about the intricacies of differences between 3.4 and 3.5 but seems that there's no harm done. Everything runs fine except for flake8 which fails on some of the test files. You can either change those files or adjust the way that flake8 runs (by excluding test files in `setup.cfg`, for example).