### PR TITLE
Error installing if numpy not installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
           env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="3.5" PYTHON_ARCH="64"
         - os: osx
           env: TEST_DEPS="numpy==1.11.0 nose cython" PYTHON_VERSION="2.7" PYTHON_ARCH="64" TEST_RUN="sdist"
+        - os: linux
+          env: PYTHON_VERSION="3.5" PYTHON_ARCH="64"
 
 before_install:
     - uname -a

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ metadata = dict(name='Bottleneck',
                 packages=find_packages(),
                 package_data={'bottleneck': ['LICENSE']},
                 requires=['numpy'],
-                install_requires=['numpy'])
+                install_requires=['numpy'],
+                setup_requires=['numpy'])
 
 
 if not(len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or


### PR DESCRIPTION
```python
  Running setup.py bdist_wheel for bottleneck: started
  Running setup.py bdist_wheel for bottleneck: finished with status 'error'
  Complete output from command /usr/local/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-GUfZRW/bottleneck/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpvm8245pip-wheel- --python-tag cp27:
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-GUfZRW/bottleneck/setup.py", line 105, in <module>
      metadata['ext_modules'] = prepare_modules()
    File "/tmp/pip-build-GUfZRW/bottleneck/setup.py", line 28, in prepare_modules
      import numpy as np
  ImportError: No module named numpy
  
  ----------------------------------------
  Failed building wheel for bottleneck
```

Not sure if this is the correct solution, and definitely not sure this is the correct way to test it, but let's see