### PR TITLE
Memory leak when input is not a numpy array

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -24,7 +24,8 @@ Bottleneck 1.3.0
 - #178 bn.push(a, n=None) raises when None is explicitly passed
 - #183 bn.nansum(a) wrong output when a = np.ones((2, 2))[..., np.newaxis]
   same issue of other reduce functions
-- #194 silenced FutureWarning from NumPy in the slow version of move functions
+- #194 Silenced FutureWarning from NumPy in the slow version of move functions
+- #201 Memory leaked when input was not a NumPy array
 
 Bottleneck 1.2.1
 ----------------


### PR DESCRIPTION
All bottleneck functions leak memory, as reported in #201, when the input is not a numpy array. 