### PR TITLE
Add a pyproject.toml file declaring build-time dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst RELEASE.rst
 include LICENSE bottleneck/LICENSE
 include Makefile tox.ini
+include pyproject.toml
 
 recursive-include bottleneck/src *.c *.h
 exclude bottleneck/src/reduce.c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
The use of ``setup_requires`` to declare build-time dependencies is problematic because it is honored by setuptools rather than pip, which means that it doesn't ignore numpy pre-releases. This in turn is causing issues at the moment because when installing bottleneck into a clean environment, it is build against numpy 1.16rc2 and then numpy 1.15 is installed, which then causes bottleneck to not work (since there was a change in API between numpy 1.15 and 1.16). For a more in-depth description of this issue, see [this post I made on numpy-discussion](https://mail.python.org/pipermail/numpy-discussion/2019-January/079097.html).

In any case, projects should now start declaring build-time dependencies using a ``pyproject.toml`` file as described in [PEP 518](https://www.python.org/dev/peps/pep-0518/). Using this (as done in this PR) will mean that this issue won't happen for pip 10.0 and later since pip will honor the build-time dependency and ``setup_requires`` will thus get ignored.

In the long term, ``setup_requires`` could in fact be removed, but there's no harm in leaving it for older versions of pip.